### PR TITLE
SOC-251 Make sure we send the user's IP not the server's IP

### DIFF
--- a/WMBridge.js
+++ b/WMBridge.js
@@ -223,17 +223,22 @@ setInterval(function() {
 	}
 }, 5000);
 
-WMBridge.prototype.ban = function(roomId, name, handshake ,time, reason, key, success, error) {
-	clearAuthenticateCache(roomId, name);
-	var requestUrl = getUrl('blockOrBanChat', {
+WMBridge.prototype.ban = function(client, name, time, reason, success, error) {
+	var roomId = client.roomId,
+		handshake = client.handshake,
+		key = client.userKey,
+		userIP = client.request.connection.remoteAddress,
+		requestUrl = getUrl('blockOrBanChat', {
 		roomId: roomId,
 		userToBan: urlencode(name),
 		time: urlencode(time),
 		reason: urlencode(reason),
 		mode: 'global',
 		key: key,
-		userIP: (handshake.address && handshake.address.address) || ''
+		userIP: userIP || ''
 	});
+
+	clearAuthenticateCache(roomId, name);
 
 	requestMW('GET', roomId, {}, requestUrl, handshake, function(data){
 		// Process response from MediaWiki server and then kick the user from all clients.

--- a/server.js
+++ b/server.js
@@ -640,7 +640,7 @@ function ban(client, socket, msg){
 	var time = banCommand.get('time');
 	var reason = banCommand.get('reason');
 
-	mwBridge.ban(client.roomId, userToBan, client.handshake, time, reason, client.userKey, function(data){
+	mwBridge.ban(client, userToBan, time, reason, function(data){
     	var kickEvent = new models.KickEvent({
     		kickedUserName: userToBan,
     		time: time,


### PR DESCRIPTION
Ban requests are currently sending the server's IP as part of the request, which is used in the activity logs.  We should be sending the user's IP.

https://wikia-inc.atlassian.net/browse/SOC-251