### PR TITLE
Soc 442 4

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ var app = require('express')()
 monitoring.startMonitoring(50000, storage);
 
 // This includes and starts the API server (which MediaWiki makes requests to).
-logger.info("== Starting the API Server ==");
+logger.info("== Starting the API Server: instance " + config.INSTANCE + "==");
 require("./server_api.js");
 
 // Start the Node Chat server (which browsers connect to).
@@ -57,7 +57,7 @@ logger.info("Next room id: " + storage._get(config.getKey_nextRoomId()));
 
 // TODO: MUST REMOVE THIS WHEN WE HAVE MULTIPLE NODE SERVERS! (and figure out another solution to prune entries who are no longer connected... perhaps prune any time you try to send to them & they're not there?).
 logger.info("Pruning old room memberships...");
-storage.purgeAllMembers();
+storage.purgeAllMembersFromInstance(config.INSTANCE);
 
 logger.info('Configured to listen on http://' +  config.CHAT_SERVER_HOST + ':' + config.CHAT_SERVER_PORT);
 server.listen(config.CHAT_SERVER_PORT, config.CHAT_SERVER_HOST, function () {
@@ -849,9 +849,7 @@ function storeAndBroadcastChatEntry(client, ioSockets, chatEntry, callback){
 			// Normally, we trust the client.myUser (it's attached to the socket) but if they mismatch, if that wasn't
 			// done intentionally by an attacker, then we likely had the session-swapping bug. Our current hypothesis is
 			// that the bug is caused by thousands of users trying to reconnect simultaneously.
-			logger.critical("-- SOCKETSWAPPING -- USER HAS LIKELY HAD THEIR SOCKET SWITCHED (that or" +
-				" they're manually attempting to spoof a message: unlikely). WE GOT A MESSAGE FROM USER " +chatEntry.get('name') +
-				" but it came through on the socket for +" + client.myUser.get('name'));
+			logger.critical("-- SOCKETSWAPPING-3 -- Got a message from user '" +chatEntry.get('name') + "' through socket for '" + client.myUser.get('name') +"'");
 		}
 
 		// Set the id from redis, and the name/avatar based on what we KNOW this client's credentials to be.

--- a/server_config.js
+++ b/server_config.js
@@ -50,6 +50,7 @@ exports.CHAT_SERVER_PORT = parseInt(chatServer[1]);
 
 exports.BASKET = arvg.basket;
 exports.INSTANCE = arvg.instance + 1;
+exports.INSTANCE_COUNT = instanceCount;
 exports.API_SERVER_HOST = apiServer[0];
 exports.API_SERVER_PORT = parseInt(apiServer[1]);
 

--- a/storage.js
+++ b/storage.js
@@ -168,20 +168,29 @@ RedisStorage.prototype = {
 	},
 	
 	/**
-	 * This will delete all room-membership lists from Redis. This is NOT safe to use when
-	 * we have multiple instances of the Node server running.
+	 * This will delete all room-membership (for the given instance) from Redis. This will cause
+	 * those rooms to be considered empty again, and if any users thought they were connected, they
+	 * will have to reconnect.
+	 *
+	 * This is typically used when starting a server-instance so that if this was a restart, the previous
+	 * occupants get cleaned out.
 	 */
-	purgeAllMembers: function(callback, errback) {
+	purgeAllMembersFromInstance: function(instanceNumber, callback, errback) {
 		var self = this;
 		self._keys(self.config.getKeyPrefix_usersInRoom()+":*", function(data) {
 			_.each(data, function(usersInRoomKey) {
 				var parts = usersInRoomKey.split(':');
 				var roomId = parts[1];
-				// TODO: INVESTIGATE: WHY DO WE DO A getRoomData() HERE? I don't see how that wgCityId is needed to do the deletion.
-				// TODO: Should we be deleting the roomData also? That would result in the wiki getting a new room id which it shouldn't.
+				
+				// Look up the wgCityId so that we can figure out what instance the room belongs to.
 				self.getRoomData(roomId, 'wgCityId', function(wgCityId) {
-					logger.debug("\tCleaning users out of room with key: " + usersInRoomKey);
-					self._del(usersInRoomKey, self._redis.print, null, self._redis.print);
+					// Only purge the users for the current instance.
+					// NOTE: This functionality is designed to mirror what's in ChatHelper.php::getServer().
+					var roomInstance = ((wgCityId % $serversCount) + 1);
+					if(roomInstance == instanceNumber){
+						logger.debug("\tCleaning users out of room with key: " + usersInRoomKey);
+						self._del(usersInRoomKey, self._redis.print, null, self._redis.print);
+					}
 				});
 			});
 		},

--- a/storage.js
+++ b/storage.js
@@ -186,7 +186,7 @@ RedisStorage.prototype = {
 				self.getRoomData(roomId, 'wgCityId', function(wgCityId) {
 					// Only purge the users for the current instance.
 					// NOTE: This functionality is designed to mirror what's in ChatHelper.php::getServer().
-					var roomInstance = ((wgCityId % this.config.INSTANCE_COUNT) + 1);
+					var roomInstance = ((wgCityId % self.config.INSTANCE_COUNT) + 1);
 					if(roomInstance == instanceNumber){
 						logger.debug("\tCleaning users out of room with key: " + usersInRoomKey);
 						self._del(usersInRoomKey, self._redis.print, null, self._redis.print);

--- a/storage.js
+++ b/storage.js
@@ -186,7 +186,7 @@ RedisStorage.prototype = {
 				self.getRoomData(roomId, 'wgCityId', function(wgCityId) {
 					// Only purge the users for the current instance.
 					// NOTE: This functionality is designed to mirror what's in ChatHelper.php::getServer().
-					var roomInstance = ((wgCityId % $serversCount) + 1);
+					var roomInstance = ((wgCityId % this.config.INSTANCE_COUNT) + 1);
 					if(roomInstance == instanceNumber){
 						logger.debug("\tCleaning users out of room with key: " + usersInRoomKey);
 						self._del(usersInRoomKey, self._redis.print, null, self._redis.print);


### PR DESCRIPTION
This includes the candidate-fix to the session-swapping when any instance goes down (unclear if it'll have an effect on what happens when the all servers are restarted at once).

Also, toned down the verbosity of the session-swapping logging, and made it more visible when a server starts up (the one line says which instance is starting & logs that as critical-level).