### PR TITLE
Soc 442 6

### DIFF
--- a/monitoring.js
+++ b/monitoring.js
@@ -92,10 +92,11 @@ exports.startMonitoring = startMonitoring = function(interval, storage) {
  *  - removing samples from redis db (24h)
  *  - sampling rate (10 secs)
  *  - sum_range (10 minutes)
- *  - flusing from memory to db (30 seconds)
+ *  - flushing from memory to db (30 seconds)
  */
 
 var eventSamples = {};
+var unsampledEvents = {};
 var resultCache = {};
 
 var SAMPLING_RATE = 10000;		// internal sampling ratio
@@ -115,7 +116,26 @@ function getEventsStats(data) {
 		cleanUpSamples(eventName, tsLimit);
 		data['event_' + eventName] = resultCache[eventName];
 	}
+	
+	// NOTE: Unsampled events will overwrite corresponding sampled events if those  exist (do not
+	// send sampled incr calls if using unsampled calls, it's just a waste of time).
+	for(eventName in unsampledEvents) {
+		data['event_' + eventName] = unsampledEvents[eventName];
+	}
 	return data;
+};
+
+/**
+ * Allows incrementing an unsampled event. NOTE: Do NOT use this function to increment values
+ * that are also incremented using incrEventCounter (the sampled version). If there is a conflict,
+ * the unsampled data will be used.
+ */
+exports.incrEventCounterUnsampled = incrEventCounterUnsampled = function(eventName) {
+	if(!eventName in unsampledEvents){
+		unsampledEvents[eventName] = 1;
+	} else {
+		unsampledEvents[eventName]++;
+	}
 };
 
 exports.incrEventCounter = incrEventCounter = function(eventName) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jade": "1.5.0",
     "request": "2.40.0",
     "qs": "1.2.2",
-    "socket.io": "1.0.6",
+    "socket.io": "1.3.5",
     "underscore": "1.6.0",
     "socket.io-client": "1.0.6",
     "redis": "0.12.1",

--- a/server.js
+++ b/server.js
@@ -43,10 +43,9 @@ io.set('transports', [  'polling'  ]);
 //io.set('authorization', authConnection );
 io.use(authConnection);
 
-// TODO: CONSIDER USING THIS HEARTBEAT... I DON'T THINK WE HAD THEM WHEN WE STARTED... BUT I THINK OUR CODE
-// IS CURRENTLY NOT GREAT AT DETECTING DISCONNECTS (default values are 25s and 60s but that doesn't do it).
-//io.set("heartbeat timeout", 20000);
-//io.set("heartbeat interval", 10000);
+// NOTE: Testing out these shorter heartbeats to improve disconnections. Default values are 25s and 60s but that doesn't work well.
+io.set("heartbeat timeout", 20000);
+io.set("heartbeat interval", 10000);
 
 //setup route (just for healthcheck)
 app.get('/*', function(req, res){
@@ -111,6 +110,8 @@ function startServer() {
 			// rewriting here, and just leave it as .handshake.clientData everywhere.
 			clientSocket[key] = clientSocket.handshake.clientData[key];
 		}
+		delete clientSocket.handshake.clientData; // clean up a small bit of memory.
+
 		monitoring.incrEventCounter('connects');
 		storage.increaseUserCount(1);
 

--- a/server.js
+++ b/server.js
@@ -27,9 +27,9 @@ var app = require('express')()
 monitoring.startMonitoring(50000, storage);
 
 // This includes and starts the API server (which MediaWiki makes requests to).
-logger.info("== Starting the API Server: instance " + config.INSTANCE + "==");
+logger.critical("== Starting the API Server: instance " + config.INSTANCE + "==");
 require("./server_api.js");
-monitoring.incrEventCounter('server_startup');
+monitoring.incrEventCounterUnsampled('server_startup');
 
 // Start the Node Chat server (which browsers connect to).
 logger.info("== Starting Node Chat Server ==");


### PR DESCRIPTION
Batch of fixes related to SOC-392 (chat crashing).

It turns out that the monitoring events are all heavily sampled (1/10,000) by default. This change adds the option to increment UNsampled events (don't mix the two for the same event, if you do: the unsampled version will always be the value sent to the server).  This unsampled event writing is used for the server_startup event.

We manually inspected logs and it looks like only 2 restarts actually happened over the weekend, which is good to know. 2 restarts in 2-3 days.

This change also makes servers-startup a CRITICAL log event so that it'll be easier to verify the exact number in logs.

Furthermore, this PR sets npm's version for socket.io to the latest version: 1.3.5. This is fine to run even with the old 1.0.6 client it seems (based on using it for a bit... probably didn't hit every corner of the code, but normal usage looked fine).

This PR also has a better setting for socket.io heartbeats. This should make disconnects happen more smoothly. They should now timeout after 25 seconds on average instead of 72 second average (10s heartbeat which averages 5 seconds after the user actually dropped + 20 second timeout - vs 25s heartbeat which averages 12 seconds after the user actually dropped + 60 second timeout).

One minor additional change is that the handshake.clientData is deleted after its done being used for transportation. This is a very small memory fix (a couple hundred bytes per connected user) but it's good to keep these objects lean when that memory has literally no purpose after we've moved it.