### PR TITLE
Soc 547

### DIFF
--- a/WMBridge.js
+++ b/WMBridge.js
@@ -189,8 +189,9 @@ var authenticateUserCache = {};
  * UTF8 characters could avoid having their auth info purged from the cache.
  */
 var clearAuthenticateCache = function(roomId, name) {
-//var cacheKey = unescape(name + "_" + roomId).replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
-logger.critical("PURGING CACHED AUTH INFO FOR ROOM: " + roomId);
+	// We purge the entire room, rather than the specific user because of variations in the way
+	// some usernames are URL/UTF8 encoded when they connect vs. when the Admin sends their name
+	// to be banned.
 	if(authenticateUserCache[roomId]) {
 		delete authenticateUserCache[roomId];
 	}
@@ -202,10 +203,10 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, suc
 	var normalizedName = unescape(name).replace(/ /g, '_');
 	if(authenticateUserCache[roomId] && authenticateUserCache[roomId][normalizedName]
 		&& (authenticateUserCache[roomId][normalizedName].key == key) ) {
-logger.critical("USED CACHE-KEY TO GRANT ACCESS: '" + roomId +"::" + normalizedName + "'");
+		logger.debug("Used authenticateUserCache to grant acess to: '" + roomId +"' for user '" + normalizedName + "'");
 		return success(authenticateUserCache[roomId][normalizedName].data);
 	}
-logger.critical("CACHE-KEY NOT FOUND IN CACHE: '" + roomId +"::" + normalizedName + "' WILL MAKE REQUEST TO MEDIAWIKI.");
+	logger.debug("User '" + normalizedName + "' not found in cache for roomId '"+roomId+"'. Server will make auth request to MediaWiki.");
 
 	var requestUrl = getUrl( 'getUserInfo', {
 		roomId: roomId,

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -183,7 +183,7 @@ var WMBridge = function() {
 var authenticateUserCache = {};
 
 var clearAuthenticateCache = function(roomId, name) {
-	name = name.replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
+	name = unescape(name).replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
 	var cacheKey = name + "_" + roomId;
 logger.critical("CLEARING THE CACHE-KEY: " + cacheKey);
 	if(authenticateUserCache[cacheKey]) {

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -183,6 +183,7 @@ var WMBridge = function() {
 var authenticateUserCache = {};
 
 var clearAuthenticateCache = function(roomId, name) {
+	name = name.replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
 	var cacheKey = name + "_" + roomId;
 logger.critical("CLEARING THE CACHE-KEY: " + cacheKey);
 	if(authenticateUserCache[cacheKey]) {
@@ -195,7 +196,7 @@ logger.critical("CLEARING THE CACHE-KEY: " + unescape(cacheKey));
 }
 
 WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, success, error) {
-	var cacheKey = unescape(name + "_" + roomId);
+	var cacheKey = unescape(name + "_" + roomId).replace(/ /g, '_');
 	// This cache is only secure because it's checking the .key alongside the cacheKey (cacheKey can be forged,
 	// but the forger would not also know the 'key' which MediaWiki generates.
 	if(authenticateUserCache[cacheKey] && authenticateUserCache[cacheKey].key == key ) {

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -183,15 +183,10 @@ var WMBridge = function() {
 var authenticateUserCache = {};
 
 var clearAuthenticateCache = function(roomId, name) {
-	name = unescape(name).replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
-	var cacheKey = name + "_" + roomId;
+	var cacheKey = unescape(name + "_" + roomId).replace(/ /g, '_'); // use standardized formatting for usernames (MediaWiki allows spaces or underscores to be used interchangeably).
 logger.critical("CLEARING THE CACHE-KEY: " + cacheKey);
 	if(authenticateUserCache[cacheKey]) {
 		delete authenticateUserCache[cacheKey];
-	}
-logger.critical("CLEARING THE CACHE-KEY: " + unescape(cacheKey));
-	if(authenticateUserCache[unescape(cacheKey)]) {
-		delete authenticateUserCache[unescape(cacheKey)];
 	}
 }
 

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -188,10 +188,14 @@ logger.critical("CLEARING THE CACHE-KEY: " + cacheKey);
 	if(authenticateUserCache[cacheKey]) {
 		delete authenticateUserCache[cacheKey];
 	}
+logger.critical("CLEARING THE CACHE-KEY: " + unescape(cacheKey));
+	if(authenticateUserCache[unescape(cacheKey)]) {
+		delete authenticateUserCache[unescape(cacheKey)];
+	}
 }
 
 WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, success, error) {
-	var cacheKey = name + "_" + roomId;
+	var cacheKey = unescape(name + "_" + roomId);
 	// This cache is only secure because it's checking the .key alongside the cacheKey (cacheKey can be forged,
 	// but the forger would not also know the 'key' which MediaWiki generates.
 	if(authenticateUserCache[cacheKey] && authenticateUserCache[cacheKey].key == key ) {

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -232,11 +232,14 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, suc
 	}, error );
 }
 
+// Expire each user's info from the cache after 15 minutes.
 setInterval(function() {
 	var ts = Math.round((new Date()).getTime() / 1000);
-	for (i in authenticateUserCache){
-		if((ts - authenticateUserCache[i].ts) > 60*15) {
-			delete authenticateUserCache[i];
+	for (roomId in authenticateUserCache){
+		for(name in authenticateUserCache[roomId]){
+			if((ts - authenticateUserCache[roomId][name].ts) > 60*15) {
+				delete authenticateUserCache[roomId][name];
+			}
 		}
 	}
 }, 5000);

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -184,6 +184,7 @@ var authenticateUserCache = {};
 
 var clearAuthenticateCache = function(roomId, name) {
 	var cacheKey = name + "_" + roomId;
+logger.critical("CLEARING THE CACHE-KEY: " + cacheKey);
 	if(authenticateUserCache[cacheKey]) {
 		delete authenticateUserCache[cacheKey];
 	}
@@ -194,8 +195,10 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, suc
 	// This cache is only secure because it's checking the .key alongside the cacheKey (cacheKey can be forged,
 	// but the forger would not also know the 'key' which MediaWiki generates.
 	if(authenticateUserCache[cacheKey] && authenticateUserCache[cacheKey].key == key ) {
+logger.critical("USED CACHE-KEY TO GRANT ACCESS: " + cacheKey);
 		return success(authenticateUserCache[cacheKey].data);
 	}
+logger.critical("CACHE-KEY NOT FOUND IN CACHE: " + cacheKey + " WILL MAKE REQUEST TO MEDIAWIKI.");
 
 	var requestUrl = getUrl( 'getUserInfo', {
 		roomId: roomId,

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -217,6 +217,11 @@ logger.critical("CACHE-KEY NOT FOUND IN CACHE: '" + roomId +"::" + normalizedNam
 	var ts = Math.round((new Date()).getTime() / 1000);
 	monitoring.incrEventCounter('authenticateUserRequest');
 	requestMW( 'GET', roomId, {}, requestUrl, handshake, function(data) {
+		if(!authenticateUserCache[roomId]){
+			// Initialize cache for room, if needed.
+			authenticateUserCache[roomId] = {};
+		}
+		// Cache entry for this user.
 		authenticateUserCache[roomId][normalizedName] = {
 			data: data,
 			key: key,

--- a/WMBridge.js
+++ b/WMBridge.js
@@ -202,10 +202,10 @@ WMBridge.prototype.authenticateUser = function(roomId, name, key, handshake, suc
 	var normalizedName = unescape(name).replace(/ /g, '_');
 	if(authenticateUserCache[roomId] && authenticateUserCache[roomId][normalizedName]
 		&& (authenticateUserCache[roomId][normalizedName].key == key) ) {
-logger.critical("USED CACHE-KEY TO GRANT ACCESS: " + cacheKey);
+logger.critical("USED CACHE-KEY TO GRANT ACCESS: '" + roomId +"::" + normalizedName + "'");
 		return success(authenticateUserCache[roomId][normalizedName].data);
 	}
-logger.critical("CACHE-KEY NOT FOUND IN CACHE: " + cacheKey + " WILL MAKE REQUEST TO MEDIAWIKI.");
+logger.critical("CACHE-KEY NOT FOUND IN CACHE: '" + roomId +"::" + normalizedName + "' WILL MAKE REQUEST TO MEDIAWIKI.");
 
 	var requestUrl = getUrl( 'getUserInfo', {
 		roomId: roomId,

--- a/server.js
+++ b/server.js
@@ -483,8 +483,8 @@ function formallyAddClient(client, ioSockets, connectedUser){
 /**
  * Called when a client disconnects from the server.
  *
- * If client has property 'doNotRemoveFromRedis' set to true, then the user will be removed from the room hash in redis (this is used
- * sometimes to prevent race conditions).
+ * If client has property 'doNotRemoveFromRedis' set to true, then the user will not be removed from the room hash
+ * in redis (this is used sometimes to prevent race conditions).
  */
 function clientDisconnect(client, ioSockets) {
 	logger.debug("clientDisconnect");


### PR DESCRIPTION
This pull request will fix the bug which allowed users to reconnect from the same window, for up to 15 minutes after being banned from chat.

The problem was that an in-memory cache of authentication data was not being purged correctly when users with spaces or unicode in their username were banned. The issue has been fixed to no-longer be dependent upon username-encoding.

The exploit was reproduced in production and development, and then I deployed the fix and verified it in development also.  See screenshots on SOC-547.